### PR TITLE
Added tls section

### DIFF
--- a/pattern-6-multitenant/otazz.yaml
+++ b/pattern-6-multitenant/otazz.yaml
@@ -18,10 +18,12 @@ processors:
 exporters:
   jaeger/acme:
     endpoint: localhost:14250
-    insecure: true
+    tls:
+      insecure: true
   jaeger/ecorp:
     endpoint: localhost:15250
-    insecure: true
+    tls:
+      insecure: true
 
 service:
   extensions: []


### PR DESCRIPTION
Exporter insecure is not available anymore. Now it's a child of tls.